### PR TITLE
Add .webapp MIME type

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,5 @@
 ﻿<FilesMatch "\.(ico|pdf|flv|jpg|jpeg|png|gif|js|css|swf)(\.gz)?$">
 Header set Expires "Thu, 15 Apr 2012 20:00:00 GMT"
 </FilesMatch>
+
+AddType application/x-web-app-manifest+json .webapp


### PR DESCRIPTION
Was running into issues with the new APK Factory work and testing with this site. Noticed it's serving example .webapp files as plain/text:

$ curl -IL http://mozqa.com/webapi-permissions-tests/manifest.webapp
