### PR TITLE
removes utf-8 bom to fix Apache error

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,4 @@
-﻿<FilesMatch "\.(ico|pdf|flv|jpg|jpeg|png|gif|js|css|swf)(\.gz)?$">
+<FilesMatch "\.(ico|pdf|flv|jpg|jpeg|png|gif|js|css|swf)(\.gz)?$">
 Header set Expires "Thu, 15 Apr 2012 20:00:00 GMT"
 </FilesMatch>
 


### PR DESCRIPTION
Hi,

I work here at Mozilla and my team is responsible for hosting this website content under mozqa.com. I'm setting up a staging environment and discovered that our new Apache server is throwing an error because of the Unicode byte-order mark in the `.htaccess` file.

I checked on the current production server and the BOM isn't included in that file:

```
$ file .htaccess
.htaccess: ASCII text
```

Not sure what changed when the file was pushed to this git repository.

This PR removes the BOM. I don't think this will be a problem to merge but definitely let me know if you have any questions. I did the following to generate this PR:

```
➜  webapi-permissions-tests git:(fixes-apache-htaccess-parse-error) file .htaccess
.htaccess: UTF-8 Unicode (with BOM) text
➜  webapi-permissions-tests git:(fixes-apache-htaccess-parse-error) vim -c "set nobomb" -c wq! .htaccess
➜  webapi-permissions-tests git:(fixes-apache-htaccess-parse-error) ✗ file .htaccess
.htaccess: ASCII text
```